### PR TITLE
Fp8 lm head

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -20,7 +20,7 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import deprecate_inference_params
-
+from megatron.core.extensions.transformer_engine import TEColumnParallelLinear
 
 class GPTModel(LanguageModule):
     """GPT Transformer language model.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -146,6 +146,9 @@ class TransformerConfig(ModelParallelConfig):
 
     mlp_alpha: Optional[float] = None
 
+    lm_head_in_fp8: bool = False
+    """Whether to use FP8 for the lm_head layer."""
+    
     ####################
     # initialization
     ####################

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -476,6 +476,13 @@ def validate_args(args, defaults={}):
         
         assert os.environ.get('CUDA_DEVICE_MAX_CONNECTIONS') != "1", \
             'FSDP always requires CUDA_DEVICE_MAX_CONNECTIONS value large than one'
+    if args.lm_head_in_fp8 and not args.untie_embeddings_and_output_weights:
+        warnings.warn(
+            "`lm_head_in_fp8` cannot be enabled when embeddings and output weights are tied. " \
+            "This would raise an error because TE layers do not support skip_weight_param_allocation. \n" \
+            "Setting lm_head_in_fp8 to False..."
+        )
+        args.lm_head_in_fp8 = False
 
     # Parameters dtype.
     args.params_dtype = torch.float

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1069,6 +1069,8 @@ def _add_transformer_engine_args(parser):
                             'Required for CUDA graphs support.')
     group.add_argument('--inference-rng-tracker', action='store_true', default=False,
                        help='Use a random number generator configured for inference.')
+    group.add_argument('--lm-head-in-fp8', action='store_true', default=False,
+                          help='Use fp8 for the lm-head (output layer) weights.')
     return parser
 
 def _add_inference_args(parser):


### PR DESCRIPTION
This PR adds the option to use FP8 for the output layer (lm-head).

P.S.
This option is possible only when the LM-head is not tied to the embedding layer.